### PR TITLE
gemspec: Drop rubyforge_project property

### DIFF
--- a/jruby_visualizer.gemspec
+++ b/jruby_visualizer.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'jrubyfx'
   s.add_dependency 'diffy'
 
-  s.rubyforge_project = "jruby_visualizer"
-
   s.files         = files
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436